### PR TITLE
Feat: 탭 아이콘 클릭 시 맨 위로 스크롤 이동(0,0)

### DIFF
--- a/src/components/common/tabBar/bottomTabBar.tsx
+++ b/src/components/common/tabBar/bottomTabBar.tsx
@@ -67,6 +67,12 @@ export const BottomTabBar = ({
 
   // 탭 선택 핸들러
   const handleSelect = (key: TabKey) => {
+    // 이미 활성화된 탭을 다시 누르면 스크롤을 맨 위로 이동
+    if (key === activeKey) {
+      window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+      return;
+    }
+
     setInternalValue(key);
     onChange?.(key);
   };


### PR DESCRIPTION
## 변경 내용 (선택)

- 하단 탭바에서 이미 선택된 탭을 다시 눌렀을 때 스크롤을 최상단(0,0)으로 이동하도록 UX를 개선
- 동일 탭 재클릭 시 window.scrollTo({ top: 0, left: 0, behavior: 'smooth' }) 실행
- 재클릭 케이스에서는 onChange 호출/탭 상태 변경 없이 스크롤만 이동하도록 처리

## 작업 내용

- BottomTabBar의 탭 선택 핸들러(handleSelect)에 “같은 탭 재선택” 분기 로직 추가
- 스크롤 이동을 부드럽게 처리하기 위해 behavior: 'smooth' 옵션 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 현재 선택된 탭을 다시 터치하면 페이지가 상단으로 부드럽게 스크롤됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->