### PR TITLE
Feat: 모음 상세 페이지에 할 일 API 연동

### DIFF
--- a/src/pages/archive/archiveDetailPage.tsx
+++ b/src/pages/archive/archiveDetailPage.tsx
@@ -235,8 +235,11 @@ const ArchiveDetailPage = () => {
     ) => (lastPage.hasMore ? allPages.length : undefined),
   });
 
-  // API 기반 task 리스트 평탄화
-  const apiTaskList = taskData?.pages.flatMap((page) => page.tasks) ?? [];
+  // API 기반 task 리스트 평탄화 (useMemo로 안정화)
+  const apiTaskList = useMemo(
+    () => taskData?.pages.flatMap((page) => page.tasks) ?? [],
+    [taskData]
+  );
 
   // 실제 화면에서 사용할 task 리스트
   const taskList = isBeforeLoginArchive ? tutorialTasks : apiTaskList;
@@ -291,23 +294,31 @@ const ArchiveDetailPage = () => {
   useEffect(() => {
     if (!isBeforeLoginArchive && apiTaskList.length > 0) {
       setLinkStates((prev) => {
+        let hasChanges = false;
         const next = { ...prev };
+
         apiTaskList.forEach((task) => {
           if (!(task.taskId in next)) {
             next[task.taskId] = task.status;
+            hasChanges = true;
           }
         });
-        return next;
+
+        return hasChanges ? next : prev;
       });
 
       setLinkEditModes((prev) => {
+        let hasChanges = false;
         const next = { ...prev };
+
         apiTaskList.forEach((task) => {
           if (!(task.taskId in next)) {
             next[task.taskId] = false;
+            hasChanges = true;
           }
         });
-        return next;
+
+        return hasChanges ? next : prev;
       });
     }
   }, [apiTaskList, isBeforeLoginArchive]);


### PR DESCRIPTION
## 변경 내용 (선택)

- 모음 상세 페이지에서 mock 기반 task 로직 제거
- listByCollection API를 사용해 실제 서버 데이터로 연동
- 삭제 시 옵티미스틱 업데이트 + 실패 시 롤백 로직 추가

## 작업 내용

- TaskResponse → Task 매핑 함수 추가 (mapTaskResponseToTask)
 - 페이지네이션 + 정렬 파라미터 서버 연동 (asc / desc)
 - 무한스크롤 loadMore 로직 API 기반으로 수정
 - 삭제 시 옵티미스틱 UI 적용 및 실패 시 롤백 처리

## 상세 설명

- 구현 방식 요약
- 주요 파일 또는 로직 설명
- 리뷰어가 봐야 할 포인트

## 스크린샷 / 영상 (선택)

| Before | After |
| ------ | ----- |
|        |       |

## 테스트 방법

1. 로컬에서 `npm start`
2. `/archive/detail/:id` 진입
3. 정상 동작 확인

## 영향 범위

- [x] UI
- [x] API
- [x] 상태 관리
- [ ] 네이티브 설정 (iOS / Android)
- [ ] 퍼포먼스

## 체크리스트

- [x] 로컬 테스트 완료

## 관련 이슈

- Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 아카이브 페이지의 무한 스크롤링 기능으로 작업 로딩 성능 향상
  * 서버 기반 페이징으로 대규모 작업 목록 효율적 관리

* **개선 사항**
  * 작업 삭제 및 완료 작업의 최적화된 데이터 처리
  * 정렬 옵션의 서버 동기화로 일관된 사용자 경험 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->