### PR TITLE
Fix: 모음 탭 EmptyNotice 및 모음 이미지 border radius 수정

### DIFF
--- a/src/components/common/list/archiveCard.tsx
+++ b/src/components/common/list/archiveCard.tsx
@@ -128,10 +128,7 @@ export default function ArchiveCard({
       <div className='flex min-h-0 min-w-0 flex-1 items-center gap-4'>
         <div className='grid size-[60px] shrink-0 grid-cols-2 grid-rows-2 gap-0.5 overflow-hidden rounded-[9.6px]'>
           {slots.map((imageSrc, index) => (
-            <div
-              key={index}
-              className='relative overflow-hidden rounded-[4px] bg-black/20'
-            >
+            <div key={index} className='relative overflow-hidden bg-black/20'>
               {imageSrc && (
                 <img
                   alt={`thumbnail-${index}`}

--- a/src/pages/archive/beforeLogin.tsx
+++ b/src/pages/archive/beforeLogin.tsx
@@ -122,7 +122,7 @@ const ArchiveBeforeLogin = () => {
             onClickAdd={handleAddArchive}
           />
         </section>
-        <section className='flex flex-col space-y-3 bg-grey-50 px-5 pb-24 pt-6'>
+        <section className='flex flex-1 flex-col bg-grey-50 px-5 pb-[26px] pt-6'>
           {filteredArchives.map((archive) => {
             const previewImages = Array.isArray(archive.images)
               ? archive.images.slice(0, 4)
@@ -148,7 +148,7 @@ const ArchiveBeforeLogin = () => {
           {filteredArchives.length === 0 && (
             <div className='flex flex-1 items-center justify-center'>
               <EmptyNotice
-                title='선택한 카테고리에 표시할 모음이 없어요.'
+                title='아직 모음이 없어요'
                 subtitle='우측 상단 모음 추가 버튼으로 추가할 수 있어요.'
               />
             </div>


### PR DESCRIPTION
- 미로그인 모음 탭 emptyNotice를 로그인 모음 탭 emptyNotice와 동일하게 수정
- 홈화면 및 모음화면 사진 border-radius 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 아카이브 목록 레이아웃을 개선했습니다. 빈 상태 메시지를 간결하게 업데이트하고, 간격과 패딩을 조정했습니다.
  * 아카이브 카드 이미지 슬롯의 스타일을 미세 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->